### PR TITLE
Added token header from documentation to make it work in Azure B2C.

### DIFF
--- a/JWT/Program.cs
+++ b/JWT/Program.cs
@@ -23,7 +23,8 @@ namespace JWT
 
             string audience = "https://appleid.apple.com";
             string issuer = ""; //team 
-            string subject = ""; //service
+            string subject = ""; //service identifier
+            string kid = ""; //service key
             string p8key = ""; //key
 
             IList<Claim> claims = new List<Claim> {
@@ -45,6 +46,8 @@ namespace JWT
                 DateTime.Now.AddDays(180),
                 signingCred
             );
+            token.Header.Add("kid", kid);
+            token.Header.Remove("typ");
 
             JwtSecurityTokenHandler tokenHandler = new JwtSecurityTokenHandler();
 


### PR DESCRIPTION
Added code to make this work with azure b2c and Apple sign in. This code is taken from https://github.com/azure-ad-b2c/samples/blob/master/policies/sign-in-with-apple/source-code/B2CSignInWithApple/SigninWithApple_ClientSecret/run.csx